### PR TITLE
ci: updating release-please language

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "changelog-type": "github",
+  "release-type": "go",
   "pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {}


### PR DESCRIPTION
The default language is Node, so changing to Go so release-please only creates a changelog.