### PR TITLE
refactor: converting to unset rather than remove

### DIFF
--- a/src/zsh-simple-abbreviations
+++ b/src/zsh-simple-abbreviations
@@ -42,21 +42,16 @@ case $1 in
 				fi
 		;;
 
-		--remove)
+		--unset)
 				if [[ $# -ne 2 ]]; then
-						echo "zsh_simple_abbreviations remove sub-command requires only a key."
+						echo "zsh_simple_abbreviations unset sub-command requires only a key."
 						return 1
 				fi
 
 				local key=${2}
 
 				if [[ "${key}" =~ ${KEY_REGEX} ]]; then
-						if [[ -n "${ZSH_SIMPLE_ABBREVIATIONS[$key]}" ]]; then
-								unset "_zsh_simple_abbreviations[$key]"
-						else
-								echo "zsh_simple_abbreviations remove sub-command key does not match any abbreviations."
-								return 1
-						fi
+						unset "ZSH_SIMPLE_ABBREVIATIONS[${key}]"
 				else
 						echo "zsh_simple_abbreviations key '${key}' contains non-alphanumeric characters."
 						return 1


### PR DESCRIPTION
Renaming to unset to indicate we will not throw an error if it did not exist.

* https://github.com/DeveloperC286/zsh-simple-abbreviations/issues/18