### PR TITLE
refactor: converting to set rather than add

### DIFF
--- a/src/zsh-simple-abbreviations
+++ b/src/zsh-simple-abbreviations
@@ -25,9 +25,9 @@ if [[ $# -eq 0 ]]; then
 fi
 
 case $1 in
-		--add)
+		--set)
 				if [[ $# -ne 3 ]]; then
-						echo "zsh_simple_abbreviations add sub-command requires a key and value."
+						echo "zsh_simple_abbreviations set sub-command requires a key and value."
 						return 1
 				fi
 
@@ -66,7 +66,7 @@ case $1 in
 				fi
 
 				for key in ${(ko)ZSH_SIMPLE_ABBREVIATIONS}; do
-						echo "zsh_simple_abbreviations --add ${key} '${ZSH_SIMPLE_ABBREVIATIONS[$key]}'"
+						echo "zsh_simple_abbreviations --set ${key} '${ZSH_SIMPLE_ABBREVIATIONS[$key]}'"
 				done
 		;;
 


### PR DESCRIPTION
Renaming to set to indicate we will not throw an error if it does already exist.

* https://github.com/DeveloperC286/zsh-simple-abbreviations/issues/11