### PR TITLE
fix: No such shell function `__zsh_simple_abbreviations::expand'

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -103,6 +103,7 @@ e2e-test:
     BUILD +setting-abbreviation-e2e-test
     BUILD +unsetting-abbreviation-e2e-test
     BUILD +no-space-does-not-expand-abbreviation-e2e-test
+    BUILD +no-abbreviations-e2e-test
 
 
 e2e-test-base:
@@ -127,3 +128,8 @@ unsetting-abbreviation-e2e-test:
 no-space-does-not-expand-abbreviation-e2e-test:
     FROM +e2e-test-base
     RUN python3 end-to-end-tests/no-space-does-not-expand-abbreviation.py
+
+
+no-abbreviations-e2e-test:
+    FROM +e2e-test-base
+    RUN python3 end-to-end-tests/no-abbreviations.py

--- a/end-to-end-tests/no-abbreviations.py
+++ b/end-to-end-tests/no-abbreviations.py
@@ -1,0 +1,31 @@
+import pexpect
+import os
+
+
+full_path = os.path.realpath(__file__)
+test_directory = os.path.dirname(full_path)
+
+zsh = pexpect.spawnu('/usr/bin/env zsh --no-rcs',
+                     env=os.environ | {'PROMPT': '>'})
+
+# Ready to take a command.
+zsh.expect('>')
+# Source the plugin and do not set an abbreviation.
+zsh.sendline(
+    f"source \"{test_directory}/../zsh-simple-abbreviations.zsh\"")
+
+# Ready to take a command.
+zsh.expect('>')
+before = zsh.after
+# Run any command.
+zsh.sendline("echo hello ")
+
+# Ready to take a command.
+zsh.expect('>')
+output = (before + zsh.before)
+# Assert the expand abbreviation function is not an issue.
+assert "zsh: command not found: echohello" not in output
+assert "\nhello" in output
+
+# Done with test close Zsh.
+zsh.close()

--- a/src/__zsh_simple_abbreviations_expand
+++ b/src/__zsh_simple_abbreviations_expand
@@ -1,0 +1,10 @@
+#!/usr/bin/env zsh
+
+emulate -L zsh -o extended_glob
+local MATCH
+# Can't use KEY_REGEX, but should match it.
+LBUFFER=${LBUFFER%%(#m)[-_a-zA-Z0-9]#}
+# If matches set abbreviation add that else just add what we attempted to match on.
+LBUFFER+=${${ZSH_SIMPLE_ABBREVIATIONS[$MATCH]}:-$MATCH}
+# Causes the syntax highlighting.
+zle self-insert

--- a/src/__zsh_simple_abbreviations_insert_space
+++ b/src/__zsh_simple_abbreviations_insert_space
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# Adds a space to the end of the command buffer.
+LBUFFER+=" "

--- a/src/zsh-simple-abbreviations
+++ b/src/zsh-simple-abbreviations
@@ -2,22 +2,6 @@
 
 KEY_REGEX="^[[:alnum:]]+$"
 
-__zsh_simple_abbreviations::expand() {
-		emulate -L zsh -o extended_glob
-		local MATCH
-		# Can't use KEY_REGEX, but should match it.
-		LBUFFER=${LBUFFER%%(#m)[-_a-zA-Z0-9]#}
-		# If matches set abbreviation add that else just add what we attempted to match on.
-		LBUFFER+=${${ZSH_SIMPLE_ABBREVIATIONS[$MATCH]}:-$MATCH}
-		# Causes the syntax highlighting.
-		zle self-insert
-}
-
-__zsh_simple_abbreviations::insert_space() {
-		# Adds a space to the end of the command buffer.
-		LBUFFER+=" "
-}
-
 if [[ $# -eq 0 ]]; then
 		echo "zsh_simple_abbreviations no sub-command or arguments provided."
 		return 1

--- a/zsh-simple-abbreviations.zsh
+++ b/zsh-simple-abbreviations.zsh
@@ -9,10 +9,12 @@ if [[ -n "${ZSH_VERSION}" ]]; then
 		autoload -Uz zsh-simple-abbreviations
 
 		# Create key binding on space to expand into a possible abbreviations.
-		zle -N __zsh_simple_abbreviations::expand
-		bindkey " "    __zsh_simple_abbreviations::expand
+		autoload -Uz __zsh_simple_abbreviations_expand
+		zle -N __zsh_simple_abbreviations_expand
+		bindkey " " __zsh_simple_abbreviations_expand
 
 		# Create key binding on control + space to insert a space without any possible abbreviations expansion.
-		zle -N __zsh_simple_abbreviations::insert_space
-		bindkey "^ "    __zsh_simple_abbreviations::insert_space
+		autoload -Uz __zsh_simple_abbreviations_insert_space
+		zle -N __zsh_simple_abbreviations_insert_space
+		bindkey "^ " __zsh_simple_abbreviations_insert_space
 fi


### PR DESCRIPTION
Closes https://github.com/DeveloperC286/zsh-simple-abbreviations/issues/12

Fixing the issue where if you never set or unset an abbreviation then you would get the error "No such shell function `__zsh_simple_abbreviations::expand'" if you used a space. Because the function was bound to the key but as the main function is autoloaded the function `__zsh_simple_abbreviations::expand' is never loaded.