### PR TITLE
build: adding ci scripts shell linting

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,6 +27,16 @@ jobs:
         uses: actions/checkout@v3
       - name: Check YAML formatting.
         run: earthly --ci +check-yaml-formatting
+  shell-linting:
+    name: Shell Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Earthly v0.8.1.
+        run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.8.1/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
+      - name: Checkout code.
+        uses: actions/checkout@v3
+      - name: Check Shell formatting.
+        run: earthly --ci +check-shell-linting
   e2e-test:
     name: End to End Test
     runs-on: ubuntu-latest

--- a/Earthfile
+++ b/Earthfile
@@ -80,6 +80,15 @@ fix-formatting:
     BUILD +fix-yaml-formatting
 
 
+check-shell-linting:
+    FROM ubuntu:22.04
+    # https://askubuntu.com/questions/462690/what-does-apt-get-fix-missing-do-and-when-is-it-useful
+    RUN apt-get update --fix-missing
+    RUN apt-get install shellcheck -y
+    DO +COPY_SOURCECODE
+    RUN ./ci/check-shell-linting.sh
+
+
 check-conventional-commits-linting:
     FROM +rust-base
     RUN cargo install conventional_commits_linter --version 0.12.3 --locked

--- a/ci/check-shell-linting.sh
+++ b/ci/check-shell-linting.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o xtrace
+
+shellcheck ./ci/*


### PR DESCRIPTION
Unable to add it for the source code as shellcheck doesn't support Z shell (Zsh).

* https://github.com/koalaman/shellcheck

Closes https://github.com/DeveloperC286/zsh-simple-abbreviations/issues/28