### PR TITLE
fix: not expanding on arguments or environment variables

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -113,6 +113,8 @@ COPY_SOURCECODE:
 
 
 e2e-test:
+    BUILD +abbreviation-finding-ignores-arguments-e2e-test
+    BUILD +abbreviation-finding-ignores-environment-variables-e2e-test
     BUILD +setting-abbreviation-e2e-test
     BUILD +unsetting-abbreviation-e2e-test
     BUILD +no-space-does-not-expand-abbreviation-e2e-test
@@ -126,6 +128,16 @@ e2e-test-base:
     RUN apt-get update --fix-missing
     RUN apt-get install zsh -y
     RUN pip3 install -r end-to-end-tests/requirements.txt
+
+
+abbreviation-finding-ignores-arguments-e2e-test:
+    FROM +e2e-test-base
+    RUN python3 end-to-end-tests/abbreviation-finding-ignores-arguments.py
+
+
+abbreviation-finding-ignores-environment-variables-e2e-test:
+    FROM +e2e-test-base
+    RUN python3 end-to-end-tests/abbreviation-finding-ignores-environment-variables.py
 
 
 setting-abbreviation-e2e-test:

--- a/end-to-end-tests/abbreviation-finding-ignores-arguments.py
+++ b/end-to-end-tests/abbreviation-finding-ignores-arguments.py
@@ -1,0 +1,32 @@
+import pexpect
+import os
+
+
+full_path = os.path.realpath(__file__)
+test_directory = os.path.dirname(full_path)
+
+zsh = pexpect.spawnu('/usr/bin/env zsh --no-rcs',
+                     env=os.environ | {'PROMPT': '>'})
+
+# Ready to take a command.
+zsh.expect('>')
+# Source the plugin and add an abbreviation.
+zsh.sendline(
+    f"source \"{test_directory}/../zsh-simple-abbreviations.zsh\" && zsh-simple-abbreviations --set C 'clear'")
+
+# Ready to take a command.
+zsh.expect('>')
+before = zsh.after
+# Use the abbreviation.
+zsh.sendline("echo 'rg -C 123'")
+
+# Ready to take a command.
+zsh.expect('>')
+output = (before + zsh.before)
+
+# Assert the abbreviation was expanded to 'hello'.
+print(output)
+assert "rg -clear 123" not in output
+
+# Done with test close Zsh.
+zsh.close()

--- a/end-to-end-tests/abbreviation-finding-ignores-environment-variables.py
+++ b/end-to-end-tests/abbreviation-finding-ignores-environment-variables.py
@@ -1,0 +1,32 @@
+import pexpect
+import os
+
+
+full_path = os.path.realpath(__file__)
+test_directory = os.path.dirname(full_path)
+
+zsh = pexpect.spawnu('/usr/bin/env zsh --no-rcs',
+                     env=os.environ | {'PROMPT': '>'})
+
+# Ready to take a command.
+zsh.expect('>')
+# Source the plugin and add an abbreviation.
+zsh.sendline(
+    f"source \"{test_directory}/../zsh-simple-abbreviations.zsh\" && zsh-simple-abbreviations --set C 'clear'")
+
+# Ready to take a command.
+zsh.expect('>')
+before = zsh.after
+# Use the abbreviation.
+zsh.sendline("echo ZSH_C ")
+
+# Ready to take a command.
+zsh.expect('>')
+output = (before + zsh.before)
+
+# Assert the abbreviation was expanded to 'hello'.
+print(output)
+assert "ZSH_clear" not in output
+
+# Done with test close Zsh.
+zsh.close()

--- a/src/__zsh_simple_abbreviations_expand
+++ b/src/__zsh_simple_abbreviations_expand
@@ -3,7 +3,7 @@
 emulate -L zsh -o extended_glob
 local MATCH
 # Can't use KEY_REGEX, but should match it.
-LBUFFER=${LBUFFER%%(#m)[[:alnum:]]#}
+LBUFFER=${LBUFFER%%(#m)[-_[:alnum:]]#}
 # If matches set abbreviation add that else just add what we attempted to match on.
 abbreviation="${ZSH_SIMPLE_ABBREVIATIONS[$MATCH]}"
 LBUFFER+=${abbreviation:-$MATCH}


### PR DESCRIPTION
The commit[1] removed '-' and '_' from the regex of finding a potential abbreviation to expand. So when presented with '-C' it took 'C' and tried to find an abbreviation and expand that, which is not the desired behaviour as it is part of a CLI argument.

Closes https://github.com/DeveloperC286/zsh-simple-abbreviations/issues/37

* [1] https://github.com/DeveloperC286/zsh-simple-abbreviations/commit/46674b98e27976fb0afaeb51a9e5bb51e1de720d