### PR TITLE
fix: updates zsh-autosuggestions after widgets

### DIFF
--- a/zsh-simple-abbreviations.zsh
+++ b/zsh-simple-abbreviations.zsh
@@ -10,11 +10,11 @@ if [[ -n ${ZSH_VERSION} ]]; then
 
 	# Create key binding on space to expand into a possible abbreviations.
 	autoload -Uz __zsh_simple_abbreviations_expand
-	zle -N __zsh_simple_abbreviations_expand
-	bindkey " " __zsh_simple_abbreviations_expand
+	zle -N zsh_simple_abbreviations_expand __zsh_simple_abbreviations_expand
+	bindkey " " zsh_simple_abbreviations_expand
 
 	# Create key binding on control + space to insert a space without any possible abbreviations expansion.
 	autoload -Uz __zsh_simple_abbreviations_insert_space
-	zle -N __zsh_simple_abbreviations_insert_space
-	bindkey "^ " __zsh_simple_abbreviations_insert_space
+	zle -N zsh_simple_abbreviations_insert_space __zsh_simple_abbreviations_insert_space
+	bindkey "^ " zsh_simple_abbreviations_insert_space
 fi


### PR DESCRIPTION
Adding unique names for the widget from the function, so the key binding uses the widget which then zsh-autosuggestions will pick up and rerun upon.

Closes https://github.com/DeveloperC286/zsh-simple-abbreviations/issues/36

* https://github.com/zsh-users/zsh-autosuggestions/tree/master