### PR TITLE
build: SAVE ARTIFACT output location fix

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -71,15 +71,15 @@ check-formatting:
 fix-shell-formatting:
     FROM +shell-formatting-base
     RUN ./ci/fix-shell-formatting.sh
-    SAVE ARTIFACT "ci/" AS LOCAL "ci/"
-    SAVE ARTIFACT "src/" AS LOCAL "src/"
-    SAVE ARTIFACT "zsh-simple-abbreviations.zsh" AS LOCAL "zsh-simple-abbreviations.zsh"
+    SAVE ARTIFACT "ci/" AS LOCAL "./"
+    SAVE ARTIFACT "src/" AS LOCAL "./"
+    SAVE ARTIFACT "zsh-simple-abbreviations.zsh" AS LOCAL "./"
 
 
 fix-yaml-formatting:
     FROM +yaml-formatting-base
     RUN ./ci/fix-yaml-formatting.sh
-    SAVE ARTIFACT ".github/" AS LOCAL ".github/"
+    SAVE ARTIFACT ".github/" AS LOCAL "./"
 
 
 fix-formatting:


### PR DESCRIPTION
The destination directory's path if it end with '/' copys to different locations if the destination exists or not locally, similar to 'cp'.

Setting the destination as './' keeps the behaviour consistent if the destination exists or not locally and lets us not repeat the name.