### PR TITLE
ci: replacing deprecated release-please GitHub Action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
[DEPRECATED] Release Please Action - please use https://github.com/googleapis/release-please-action