### PR TITLE
feat: add --list command to view current abbreviations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,4 @@ end-to-end-test:
 	docker run $(DOCKER_RUN_OPTS) end-to-end-test end-to-end-tests/unsetting-abbreviation.py
 	docker run $(DOCKER_RUN_OPTS) end-to-end-test end-to-end-tests/no-space-does-not-expand-abbreviation.py
 	docker run $(DOCKER_RUN_OPTS) end-to-end-test end-to-end-tests/no-abbreviations.py
+	docker run $(DOCKER_RUN_OPTS) end-to-end-test end-to-end-tests/listing-abbreviations.py

--- a/end-to-end-tests/listing-abbreviations.py
+++ b/end-to-end-tests/listing-abbreviations.py
@@ -1,0 +1,40 @@
+import pexpect
+import os
+
+
+full_path = os.path.realpath(__file__)
+test_directory = os.path.dirname(full_path)
+
+zsh = pexpect.spawnu('/usr/bin/env zsh --no-rcs',
+                     env=os.environ | {'PROMPT': '>'})
+
+# Ready to take a command.
+zsh.expect('>')
+# Source the plugin and test listing with no abbreviations.
+zsh.sendline(
+    f"source \"{test_directory}/../zsh-simple-abbreviations.zsh\" && zsh-simple-abbreviations --list")
+
+# Ready to take a command.
+zsh.expect('>')
+output = zsh.before
+
+# Assert no abbreviations message is shown.
+assert "No abbreviations set." in output
+
+# Set some abbreviations.
+zsh.sendline("zsh-simple-abbreviations --set GP 'git pull'")
+zsh.expect('>')
+zsh.sendline("zsh-simple-abbreviations --set GS 'git status'")
+zsh.expect('>')
+
+# List abbreviations.
+zsh.sendline("zsh-simple-abbreviations --list")
+zsh.expect('>')
+output = zsh.before
+
+# Assert both abbreviations are listed.
+assert "GP -> git pull" in output
+assert "GS -> git status" in output
+
+# Done with test close Zsh.
+zsh.close()

--- a/src/zsh-simple-abbreviations
+++ b/src/zsh-simple-abbreviations
@@ -41,6 +41,22 @@ case $1 in
 	fi
 	;;
 
+--list)
+	if [[ $# -ne 1 ]]; then
+		echo "zsh_simple_abbreviations list sub-command takes no arguments."
+		return 1
+	fi
+
+	if [[ ${#ZSH_SIMPLE_ABBREVIATIONS[@]} -eq 0 ]]; then
+		echo "No abbreviations set."
+		return 0
+	fi
+
+	for key in ${(k)ZSH_SIMPLE_ABBREVIATIONS}; do
+		echo "${key} -> ${ZSH_SIMPLE_ABBREVIATIONS[$key]}"
+	done
+	;;
+
 *)
 	echo "zsh_simple_abbreviations unrecognised sub-command."
 	return 1


### PR DESCRIPTION
This PR implements the list functionality requested in issue #170.

## Changes
- Add `--list` option to display all currently set abbreviations
- Show 'No abbreviations set.' message when no abbreviations exist
- Format output as 'key -> value' for each abbreviation
- Add comprehensive end-to-end test for list functionality
- Update Makefile to include new test in end-to-end-test target

Fixes #170
